### PR TITLE
bumping ts version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "node-fetch": "^2.6.1",
     "prettier": "2.1.1",
     "ts-jest": "^24.1.0",
-    "typescript": "^3.6.4"
+    "typescript": "^4.0.0"
   },
   "description": "Basic scaffold to run Lambda functions",
   "name": "lambda-scaffold",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4256,10 +4256,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^3.6.4:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
-  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
+typescript@^4.0.0:
+  version "4.1.5"
+  resolved "https://extend-159581800400.d.codeartifact.us-east-1.amazonaws.com:443/npm/extend-npm/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
+  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
 uglify-js@^3.1.4:
   version "3.12.1"


### PR DESCRIPTION
Bumping version to `4.0.0` to remove `Catch clause variable cannot have a type annotation` errors